### PR TITLE
added installation method for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,24 @@ brew install terminal-notifier
 ![terminal-notifier](./preview/terminal-notifier.png)
 
 ### Linux
+- Arch Linux
 
-直接下载[Linux可执行文件](./bin/musicfox.ubuntu)，在终端中执行。
+从[AUR](https://aur.archlinux.org/packages/musicfox/)安装 musicfox 
+
+```sh
+# 使用 AUR helper 
+# yay
+yay -S musicfox
+# pikaur
+pikaur -S musicfox
+
+# 手动安装
+git clone https://aur.archlinux.org/musicfox.git
+cd musicfox
+makepkg -si
+```
+
+- 直接下载[Linux可执行文件](./bin/musicfox.ubuntu)，在终端中执行。
 
 > 本人没有Linux系统，该执行文件是在WSL2(Ubuntu 2004)下打包的，不保证其他Linux系统也能正常使用
 


### PR DESCRIPTION
Hi, I have submitted musicfox to [AUR](https://aur.archlinux.org/packages/musicfox/), the User Repository driven by Arch Linux Users.
Arch Linux user could install and upgrade musicfox with a very simple way from AUR.
I have tested musicfox on Arch Linux compile with Dart 2.10.4, it works very fine !
Thanks for your works. 
![image](https://user-images.githubusercontent.com/24363384/102705939-059d0100-42c8-11eb-9db2-c8b98c5247fa.png)
